### PR TITLE
New External Lost Report routes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the latest uv image with python 3.13 and alpine
-FROM ghcr.io/astral-sh/uv:python3.13-alpine
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 
 COPY . /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Use the latest uv image with python 3.13 and alpine
+# Use the latest uv image with python 3.13 and debian slim
 FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 
 COPY . /app

--- a/server/app.py
+++ b/server/app.py
@@ -12,15 +12,29 @@ from server.routes.laf import router as LAFRouter
 from server.routes.loanertech import router as LoanerTechRouter
 
 
+def traces_sampler(sampling_context) -> float:
+    transaction_name = sampling_context.get("transaction_context", {}).get("name")
+    if transaction_name and any(
+        transaction_name.endswith(route) for route in settings.EXCLUDED_ROUTES
+    ):
+        return 0.0
+    return settings.SENTRY_TRACE_RATE
+
+
+def profiles_sampler(sampling_context) -> float:
+    transaction_name = sampling_context.get("transaction_context", {}).get("name")
+    if transaction_name and any(
+        transaction_name.endswith(route) for route in settings.EXCLUDED_ROUTES
+    ):
+        return 0.0
+    return settings.SENTRY_PROFILE_RATE
+
+
 sentry_sdk.init(
     dsn=settings.SENTRY_DSN,
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for tracing.
-    traces_sample_rate=settings.SENTRY_TRACE_RATE,
-    # Set profiles_sample_rate to 1.0 to profile 100%
-    # of sampled transactions.
-    # We recommend adjusting this value in production.
+    traces_sampler=traces_sampler,
     profiles_sample_rate=settings.SENTRY_PROFILE_RATE,
+    profiles_sampler=profiles_sampler,
 )
 
 

--- a/server/config.py
+++ b/server/config.py
@@ -21,7 +21,7 @@ class Settings(BaseSettings):
     SENTRY_PROFILE_RATE: float = float(os.getenv("SENTRY_PROFILE_RATE", 1.0))
 
     # Define routes to exclude from tracing and profiling
-    EXCLUDED_ROUTES = {"/", "/openapi.json", "/docs"}
+    EXCLUDED_ROUTES: set = {"/", "/openapi.json", "/docs"}
 
     model_config = SettingsConfigDict(env_file=".env")
 

--- a/server/config.py
+++ b/server/config.py
@@ -20,6 +20,9 @@ class Settings(BaseSettings):
     SENTRY_TRACE_RATE: float = float(os.getenv("SENTRY_TRACE_RATE", 1.0))
     SENTRY_PROFILE_RATE: float = float(os.getenv("SENTRY_PROFILE_RATE", 1.0))
 
+    # Define routes to exclude from tracing and profiling
+    EXCLUDED_ROUTES = {"/", "/openapi.json", "/docs"}
+
     model_config = SettingsConfigDict(env_file=".env")
 
 

--- a/server/database/laf.py
+++ b/server/database/laf.py
@@ -460,6 +460,25 @@ async def update_lost_report_item(lost_report_id: str, lost_report_data: dict) -
     return await update_lost_report(lost_report_id, lost_report_data, now)
 
 
+async def retrieve_new_lost_report_count() -> int:
+    return await lost_reports_collection.count_documents({"viewed": False})
+
+
+async def retrieve_new_lost_reports(limit: int = 30) -> list:
+    query = {"viewed": False}
+    lost_reports = []
+    async for laf_item in (
+        lost_reports_collection.find(query).sort("date", -1).limit(limit)
+    ):
+        lost_reports.append(await lost_report_helper(laf_item))
+    return lost_reports
+
+
+async def mark_lost_report_as_viewed(lost_report_id: str) -> bool:
+    now = datetime.now()
+    return await update_lost_report(lost_report_id, {"viewed": True}, now)
+
+
 lost_report_query_mapping = {
     "dateFilter": lambda v, lost_report_query_data: (
         {"date": {"$lte": lost_report_query_data["date"]}}

--- a/server/models/__init__.py
+++ b/server/models/__init__.py
@@ -14,3 +14,7 @@ class BoolResponse(ResponseModel):
 
 class StringListResponse(ResponseModel):
     data: list[str]
+
+
+class IntResponse(ResponseModel):
+    data: int

--- a/server/routes/laf.py
+++ b/server/routes/laf.py
@@ -349,7 +349,7 @@ async def update_lost_report_route(
 
 
 @router.get(
-    "/report/new/count",
+    "/reports/new/count",
     response_description="Get the number of new reports",
     response_model=IntResponse,
 )
@@ -361,7 +361,7 @@ async def get_new_report_count(auth: dict = Depends(required_auth)) -> IntRespon
 
 
 @router.get(
-    "/report/new",
+    "/reports/new",
     response_description="Get the new reports",
     response_model=LostReportItemsResponse,
 )
@@ -374,7 +374,7 @@ async def get_new_reports(
 
 
 @router.put(
-    f"/report/new/viewed/{id}",
+    "/reports/new/viewed/{id}",
     response_description="Mark a new lost report as viewed",
     response_model=BoolResponse,
 )

--- a/server/routes/laf.py
+++ b/server/routes/laf.py
@@ -20,9 +20,12 @@ from server.database.laf import (
     retrieve_lost_reports,
     update_laf_item,
     update_lost_report_item,
+    retrieve_new_lost_report_count,
+    retrieve_new_lost_reports,
+    mark_lost_report_as_viewed,
 )
 from server.helpers.auth import required_auth, simple_auth_check
-from server.models import BoolResponse, StringListResponse
+from server.models import BoolResponse, StringListResponse, IntResponse
 from server.models.laf import (
     DateFilter,
     DateString,
@@ -343,3 +346,41 @@ async def update_lost_report_route(
     if await update_lost_report_item(id, dict_lost_report):
         return BoolResponse(data=True, message="Lost Report updated successfully")
     raise HTTPException(status_code=500, detail="Failed to update a Lost Report")
+
+
+@router.get(
+    "/report/new/count",
+    response_description="Get the number of new reports",
+    response_model=IntResponse,
+)
+async def get_new_report_count(auth: dict = Depends(required_auth)) -> IntResponse:
+    return IntResponse(
+        data=await retrieve_new_lost_report_count(),
+        message="Lost Report count retrieved",
+    )
+
+
+@router.get(
+    "/report/new",
+    response_description="Get the new reports",
+    response_model=LostReportItemsResponse,
+)
+async def get_new_reports(
+    auth: dict = Depends(required_auth),
+) -> LostReportItemsResponse:
+    return LostReportItemsResponse(
+        data=await retrieve_new_lost_reports(), message="New Lost Reports retrieved"
+    )
+
+
+@router.put(
+    f"/report/new/viewed/{id}",
+    response_description="Mark a new lost report as viewed",
+    response_model=BoolResponse,
+)
+async def mark_new_report_as_viewed(
+    id: str, auth: dict = Depends(required_auth)
+) -> BoolResponse:
+    return BoolResponse(
+        data=await mark_lost_report_as_viewed(id), message="New report marked as viewed"
+    )


### PR DESCRIPTION
Routes to handle data for lost reports made externally
OP#62

- **new db functions to fetch and update new lost reports**
- **new int response**
- **add new routes for new lost reports**
- **remove uneeded sentry tracing and profiling No need to follow the base (health) route and docs route as those are unimportant to the application's running performance or errors**
- **fix issue with set**
- **update route names**
